### PR TITLE
Change LoadConf to not escape %#! in passwords as it causes auth issues.

### DIFF
--- a/plugin/vim-arsync.vim
+++ b/plugin/vim-arsync.vim
@@ -15,6 +15,9 @@ function! LoadConf()
             if l:var_name == 'ignore_path'
                 let l:var_value = eval(substitute(i[stridx(i, ' '):], '^\s*\(.\{-}\)\s*$', '\1', ''))
                 " echo substitute(i[stridx(i, ' '):], '^\s*\(.\{-}\)\s*$', '\1', '')
+            elseif l:var_name == 'remote_passwd'
+                " Do not escape characters in passwords.
+                let l:var_value = substitute(i[stridx(i, ' '):], '^\s*\(.\{-}\)\s*$', '\1', '')
             else
                 let l:var_value = escape(substitute(i[stridx(i, ' '):], '^\s*\(.\{-}\)\s*$', '\1', ''), '%#!')
             endif


### PR DESCRIPTION
I was having issues with passwords that had `%`, `#`, `!`, as the authentication fails using sshpass (because the password obviously has an extra `\` in it). 

Let me know if this causes other issues and I can look into those and fix them.